### PR TITLE
Modify the plugin components to support both Python2 and Python3

### DIFF
--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -634,7 +634,7 @@ class view(object):
         # FIXME: creating a view in another tab is not supported yet
 
     def __get_buffer(self, target):
-        builtin = __incpy__.builtin
+        six, builtin = __incpy__.six, __incpy__.builtin
         if builtin.isinstance(target, six.integer_types):
             return __incpy__.buffer.from_id(target)
         elif builtin.isinstance(target, six.string_types):

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -415,7 +415,7 @@ class interpreter_external(__incpy__.interpreter):
     @__incpy__.builtin.classmethod
     def new(cls, command, **options):
         res = cls(**options)
-        __incpy__.builtin.map(lambda n, d=options: d.pop(n, None), cls.view_options)
+        [ options.pop(item, None) for item in cls.view_options ]
         res.command,res.options = command,options
         return res
     def attach(self):
@@ -477,11 +477,11 @@ class internal(object):
 
         getCurrent = __incpy__.builtin.staticmethod(lambda: __incpy__.builtin.int(__incpy__.vim.eval('tabpagenr()')) - 1)
         getCount = __incpy__.builtin.staticmethod(lambda: __incpy__.builtin.int(__incpy__.vim.eval('tabpagenr("$")')))
-        getBuffers = __incpy__.builtin.staticmethod(lambda n: __incpy__.builtin.map(int,__incpy__.vim.eval("tabpagebuflist({:d})".format(n-1))))
+        getBuffers = __incpy__.builtin.staticmethod(lambda n: [ __incpy__.builtin.int(item) for item in __incpy__.vim.eval("tabpagebuflist({:d})".format(n - 1)) ])
 
-        getWindowCurrent = __incpy__.builtin.staticmethod(lambda n: __incpy__.builtin.int(__incpy__.vim.eval("tabpagewinnr({:d})".format(n-1))))
-        getWindowPrevious = __incpy__.builtin.staticmethod(lambda n: __incpy__.builtin.int(__incpy__.vim.eval("tabpagewinnr({:d}, '#')".format(n-1))))
-        getWindowCount = __incpy__.builtin.staticmethod(lambda n: __incpy__.builtin.int(__incpy__.vim.eval("tabpagewinnr({:d}, '$')".format(n-1))))
+        getWindowCurrent = __incpy__.builtin.staticmethod(lambda n: __incpy__.builtin.int(__incpy__.vim.eval("tabpagewinnr({:d})".format(n - 1))))
+        getWindowPrevious = __incpy__.builtin.staticmethod(lambda n: __incpy__.builtin.int(__incpy__.vim.eval("tabpagewinnr({:d}, '#')".format(n - 1))))
+        getWindowCount = __incpy__.builtin.staticmethod(lambda n: __incpy__.builtin.int(__incpy__.vim.eval("tabpagewinnr({:d}, '$')".format(n - 1))))
 
     class buffer(object):
         """Internal vim commands for getting information about a buffer"""
@@ -529,13 +529,13 @@ class internal(object):
         @__incpy__.builtin.staticmethod
         def select(window):
             '''Select the window with the specified id'''
-            return (__incpy__.builtin.int(__incpy__.vim.eval('winnr()')),__incpy__.vim.command("{:d} wincmd w".format(window)))[0]
+            return (__incpy__.builtin.int(__incpy__.vim.eval('winnr()')), __incpy__.vim.command("{:d} wincmd w".format(window)))[0]
         @__incpy__.builtin.staticmethod
         def currentsize(position):
             builtin = __incpy__.builtin
-            if position in ('left','right'):
+            if position in ('left', 'right'):
                 return builtin.int(__incpy__.vim.eval('winwidth(0)'))
-            if position in ('above','below'):
+            if position in ('above', 'below'):
                 return builtin.int(__incpy__.vim.eval('winheight(0)'))
             raise builtin.ValueError(position)
 
@@ -608,7 +608,7 @@ class internal(object):
         @__incpy__.builtin.classmethod
         def savesize(cls, bufferid):
             last = cls.select( cls.buffer(bufferid) )
-            w,h = __incpy__.builtin.map(__incpy__.vim.eval, ('winwidth(0)','winheight(0)'))
+            w, h = __incpy__.builtin.map(__incpy__.vim.eval, ['winwidth(0)', 'winheight(0)'])
             cls.select(last)
             return { 'width':w, 'height':h }
         @__incpy__.builtin.classmethod
@@ -689,7 +689,7 @@ __incpy__.view = view; del(view)
 
 # spawn interpreter requested by user
 _ = __incpy__.vim.gvars["incpy#Program"]
-opt = {'winfixwidth':True,'winfixheight':True} if __incpy__.vim.gvars["incpy#WindowFixed"]>0 else {}
+opt = {'winfixwidth':True,'winfixheight':True} if __incpy__.vim.gvars["incpy#WindowFixed"] > 0 else {}
 try:
     __incpy__.cache = __incpy__.interpreter_external.new(_, opt=opt) if len(_) > 0 else __incpy__.interpreter_python_internal.new(opt=opt)
 except:

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -95,7 +95,7 @@
 "   buffer so that management of multiple program buffers would be local to
 "   whatever the user is currently editing.
 
-if has("python")
+if has("python") || has("python3")
 
 """ Utility functions for indentation stuff
 function! s:count_indent(string)
@@ -330,8 +330,10 @@ class interpreter(object):
         opt.update(kwds.pop('opt',{}))
         kwds.setdefault('preview', __incpy__.vim.gvars['incpy#WindowPreview'])
         kwds.setdefault('tab', __incpy__.internal.tab.getCurrent())
-        self.view = __incpy__.view(kwds.pop('buffer',None) or __incpy__.vim.gvars['incpy#WindowName'], opt, **kwds)
+        self.view = __incpy__.view(kwds.pop('buffer', None) or __incpy__.vim.gvars['incpy#WindowName'], opt, **kwds)
     def __del__(self):
+        if __incpy__.sys.version_info.major >= 3:
+            return
         return self.detach()
     def write(self, data):
         """Writes data directly into view"""
@@ -693,7 +695,7 @@ opt = {'winfixwidth':True,'winfixheight':True} if __incpy__.vim.gvars["incpy#Win
 try:
     __incpy__.cache = __incpy__.interpreter_external.new(_, opt=opt) if len(_) > 0 else __incpy__.interpreter_python_internal.new(opt=opt)
 except:
-    __incpy__.logger.fatal("error starting external interpreter: {:s}".format(_.decode('ascii')), exc_info=True)
+    __incpy__.logger.fatal("error starting external interpreter: {:s}".format(_), exc_info=True)
     __incpy__.logger.warning("falling back to internal python interpreter")
     __incpy__.cache = __incpy__.interpreter_python_internal.new(opt=opt)
 del(opt)

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -389,7 +389,7 @@ class interpreter_python_internal(__incpy__.interpreter):
         except StopIteration:
             pass
 
-        logger.warn("detaching internal interpreter from sys.stdin, sys.stdout, and sys.stderr.")
+        logger.warning("detaching internal interpreter from sys.stdin, sys.stdout, and sys.stderr.")
 
         # notify the user that we're restoring the original state
         logger.debug("restoring sys.stdin, sys.stdout, and sys.stderr from: {!r}".format(self.state))
@@ -404,7 +404,7 @@ class interpreter_python_internal(__incpy__.interpreter):
             self.view.write(echo)
         __incpy__.six.exec_(data, __incpy__.builtin.globals())
     def start(self):
-        __incpy__.logger.warn("internal interpreter has already been (implicitly) started")
+        __incpy__.logger.warning("internal interpreter has already been (implicitly) started")
     def stop(self):
         __incpy__.logger.fatal("unable to stop internal interpreter as it is always running")
 __incpy__.interpreter_python_internal = interpreter_python_internal; del(interpreter_python_internal)
@@ -640,7 +640,7 @@ class view(object):
         elif builtin.isinstance(target, six.string_types):
             try: return __incpy__.buffer.from_name(target)
             except: return __incpy__.buffer.new(target)
-        raise __incpy__.incpy.error("Unable to determine output buffer from parameter : {!r}".format(target))
+        raise __incpy__.incpy.vim.error("Unable to determine output buffer from parameter : {!r}".format(target))
 
     def write(self, data):
         """Write data directly into window contents (updating buffer)"""
@@ -693,8 +693,8 @@ opt = {'winfixwidth':True,'winfixheight':True} if __incpy__.vim.gvars["incpy#Win
 try:
     __incpy__.cache = __incpy__.interpreter_external.new(_, opt=opt) if len(_) > 0 else __incpy__.interpreter_python_internal.new(opt=opt)
 except:
-    __incpy__.logger.fatal("error starting external interpreter: {:s}".format(_), exc_info=True)
-    __incpy__.logger.warn("falling back to internal python interpreter")
+    __incpy__.logger.fatal("error starting external interpreter: {:s}".format(_.decode('ascii')), exc_info=True)
+    __incpy__.logger.warning("falling back to internal python interpreter")
     __incpy__.cache = __incpy__.interpreter_python_internal.new(opt=opt)
 del(opt)
 

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -499,14 +499,14 @@ class internal(object):
                 return 'leftabove'
             if position in ('right','below'):
                 return 'rightbelow'
-            raise __incpy__.builtin.ValueError, position
+            raise __incpy__.builtin.ValueError(position)
         @__incpy__.builtin.staticmethod
         def positionToSplit(position):
             if position in ('left','right'):
                 return 'vsplit'
             if position in ('above','below'):
                 return 'split'
-            raise __incpy__.builtin.ValueError, position
+            raise __incpy__.builtin.ValueError(position)
         @__incpy__.builtin.staticmethod
         def optionsToCommandLine(options):
             builtin = __incpy__.builtin
@@ -537,7 +537,7 @@ class internal(object):
                 return builtin.int(__incpy__.vim.eval('winwidth(0)'))
             if position in ('above','below'):
                 return builtin.int(__incpy__.vim.eval('winheight(0)'))
-            raise builtin.ValueError, position
+            raise builtin.ValueError(position)
 
         # properties
         @__incpy__.builtin.staticmethod
@@ -640,7 +640,7 @@ class view(object):
         elif builtin.isinstance(target, six.string_types):
             try: return __incpy__.buffer.from_name(target)
             except: return __incpy__.buffer.new(target)
-        raise __incpy__.incpy.error, "Unable to determine output buffer from parameter : {!r}".format(target)
+        raise __incpy__.incpy.error("Unable to determine output buffer from parameter : {!r}".format(target))
 
     def write(self, data):
         """Write data directly into window contents (updating buffer)"""
@@ -651,13 +651,13 @@ class view(object):
         builtin = __incpy__.builtin
         buf = self.buffer
         if __incpy__.internal.buffer.number(buf.number) == -1:
-            raise builtin.Exception, "Buffer {:d} does not exist".format(buf.number)
+            raise builtin.Exception("Buffer {:d} does not exist".format(buf.number))
         if 1.0 <= ratio < 0.0:
-            raise builtin.Exception, "Specified ratio is out of bounds {!r}".format(ratio)
+            raise builtin.Exception("Specified ratio is out of bounds {!r}".format(ratio))
 
         current = __incpy__.internal.window.current()
         sz = __incpy__.internal.window.currentsize(position) * ratio
-        result = __incpy__.internal.window.create(buf.number, position, int(sz), self.options, preview=self.preview)
+        result = __incpy__.internal.window.create(buf.number, position, __incpy__.builtin.int(sz), self.options, preview=self.preview)
         self.window = result
         return result
 
@@ -666,9 +666,9 @@ class view(object):
         builtin = __incpy__.builtin
         buf = self.buffer
         if __incpy__.internal.buffer.number(buf.number) == -1:
-            raise builtin.Exception, "Buffer {:d} does not exist".format(buf.number)
+            raise builtin.Exception("Buffer {:d} does not exist".format(buf.number))
         if __incpy__.internal.buffer.window(buf.number) != -1:
-            raise builtin.Exception, "Window for {:d} is already showing".format(buf.number)
+            raise builtin.Exception("Window for {:d} is already showing".format(buf.number))
         __incpy__.internal.window.show(buf.number, position, preview=self.preview)
 
     def hide(self):
@@ -676,9 +676,9 @@ class view(object):
         builtin = __incpy__.builtin
         buf = self.buffer
         if __incpy__.internal.buffer.number(buf.number) == -1:
-            raise builtin.Exception, "Buffer {:d} does not exist".format(buf.number)
+            raise builtin.Exception("Buffer {:d} does not exist".format(buf.number))
         if __incpy__.internal.buffer.window(buf.number) == -1:
-            raise builtin.Exception, "Window for {:d} is already hidden".format(buf.number)
+            raise builtin.Exception("Window for {:d} is already hidden".format(buf.number))
         __incpy__.internal.window.hide(buf.number, preview=self.preview)
 
     def __repr__(self):

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -243,14 +243,14 @@ function! incpy#SetupPython(currentscriptpath)
     " FIXME: use sys.meta_path
 
     " setup the default logger
-    python __import__('logging').basicConfig()
-    python __import__('logging').getLogger('incpy')
+    pythonx __import__('logging').basicConfig()
+    pythonx __import__('logging').getLogger('incpy')
 
     " add the python path using the runtimepath directory that this script is contained in
     for p in split(&runtimepath, ",")
         let p = substitute(p, "\\", "/", "g")
         if stridx(m, p, 0) == 0
-            execute printf("python __import__('sys').path.append('%s/python')", p)
+            execute printf("pythonx __import__('sys').path.append('%s/python')", p)
             return
         endif
     endfor
@@ -258,7 +258,7 @@ function! incpy#SetupPython(currentscriptpath)
     " otherwise, look up from our current script's directory for a python sub-directory
     let p = finddir("python", m . ";")
     if isdirectory(p)
-        execute printf("python __import__('sys').path.append('%s')", p)
+        execute printf("pythonx __import__('sys').path.append('%s')", p)
         return
     endif
 
@@ -298,14 +298,14 @@ function! incpy#Setup()
     " Set any the options for the python module part.
     if g:incpy#Greenlets > 0
         " If greenlets were specified, then enable it by importing 'gevent' into the current python environment
-        python __import__('gevent')
+        pythonx __import__('gevent')
     elseif g:incpy#Program != ""
         " Otherwise we only need to warn the user that they should use it if they're trying to run an external program
         echohl WarningMsg | echomsg "WARNING:incpy.vim:Using vim-incpy to run an external program without support for greenlets will be unstable" | echohl None
     endif
 
     " Initialize the python __incpy__ namespace
-    python <<EOF
+    pythonx <<EOF
 
 # create a pseudo-builtin module
 __incpy__ = __builtins__.__class__('__incpy__', 'Internal state module for vim-incpy')
@@ -712,23 +712,23 @@ endfunction
 """ Plugin management interface
 function! incpy#Start()
     " Start the target program and attach it to a buffer
-    python __incpy__.cache.start()
+    pythonx __incpy__.cache.start()
 endfunction
 
 function! incpy#Stop()
     " Stop the target program and detach it from its buffer
-    python __incpy__.cache.stop()
+    pythonx __incpy__.cache.stop()
 endfunction
 
 function! incpy#Restart()
     " Restart the target program
-    python __incpy__.cache.stop()
-    python __incpy__.cache.start()
+    pythonx __incpy__.cache.stop()
+    pythonx __incpy__.cache.start()
 endfunction
 
 """ Plugin interaction interface
 function! incpy#Execute(line)
-    execute printf("python __incpy__.cache.communicate('%s')", escape(a:line, "'\\"))
+    execute printf("pythonx __incpy__.cache.communicate('%s')", escape(a:line, "'\\"))
     if g:incpy#OutputFollow
         call s:windowtail(g:incpy#BufferId)
     endif
@@ -746,7 +746,7 @@ function! incpy#Range(begin, end)
 
     " Execute the lines in our target
     let code_s = join(map(lines, 'escape(v:val, "''\\")'), "\\n")
-    execute printf("python __incpy__.cache.communicate('%s')", code_s)
+    execute printf("pythonx __incpy__.cache.communicate('%s')", code_s)
 
     " If the user configured us to follow the output, then do as we were told.
     if g:incpy#OutputFollow
@@ -756,7 +756,7 @@ endfunction
 
 function! incpy#Evaluate(expr)
     " Evaluate and emit an expression in the target using the plugin
-    execute printf("python __incpy__.cache.communicate(\"%s\".format(\"%s\"))", s:singleline(g:incpy#EvalFormat, "\"\\"), escape(a:expr, "\"\\"))
+    execute printf("pythonx __incpy__.cache.communicate(\"%s\".format(\"%s\"))", s:singleline(g:incpy#EvalFormat, "\"\\"), escape(a:expr, "\"\\"))
 
     if g:incpy#OutputFollow
         call s:windowtail(g:incpy#BufferId)
@@ -768,7 +768,7 @@ function! incpy#Halp(expr)
     let LetMeSeeYouStripped = substitute(a:expr, '^[ \t\n]\+\|[ \t\n]\+$', '', 'g')
 
     " Execute g:incpy#HelpFormat in the target using the plugin's cached communicator
-    execute printf("python __incpy__.cache.communicate(\"%s\".format(\"%s\"))", s:singleline(g:incpy#HelpFormat, "\"\\"), escape(LetMeSeeYouStripped, "\"\\"))
+    execute printf("pythonx __incpy__.cache.communicate(\"%s\".format(\"%s\"))", s:singleline(g:incpy#HelpFormat, "\"\\"), escape(LetMeSeeYouStripped, "\"\\"))
 endfunction
 
 """ Actual execution and setup of the plugin
@@ -780,15 +780,15 @@ endfunction
     call incpy#SetupKeys()
 
     " on entry, silently import the user module to honor any user-specific configurations
-    autocmd VimEnter * python hasattr(__incpy__, 'cache') and __incpy__.cache.attach()
-    autocmd VimLeavePre * python hasattr(__incpy__, 'cache') and __incpy__.cache.detach()
+    autocmd VimEnter * pythonx hasattr(__incpy__, 'cache') and __incpy__.cache.attach()
+    autocmd VimLeavePre * pythonx hasattr(__incpy__, 'cache') and __incpy__.cache.detach()
 
     " if greenlets were specifed then make sure to update them during cursor movement
     if g:incpy#Greenlets > 0
-        autocmd CursorHold * python __import__('gevent').idle(0.0)
-        autocmd CursorHoldI * python __import__('gevent').idle(0.0)
-        autocmd CursorMoved * python __import__('gevent').idle(0.0)
-        autocmd CursorMovedI * python __import__('gevent').idle(0.0)
+        autocmd CursorHold * pythonx __import__('gevent').idle(0.0)
+        autocmd CursorHoldI * pythonx __import__('gevent').idle(0.0)
+        autocmd CursorMoved * pythonx __import__('gevent').idle(0.0)
+        autocmd CursorMovedI * pythonx __import__('gevent').idle(0.0)
     endif
 
 else

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -218,7 +218,7 @@ function! incpy#SetupOptions()
     let defopts["WindowOptions"] = {"buftype":"nowrite", "noswapfile":[], "updatecount":0, "nobuflisted":[], "filetype":"python"}
     let defopts["WindowPreview"] = 0
     let defopts["WindowFixed"] = 0
-    let python_builtins = "__import__(\"__builtin__\")"
+    let python_builtins = "__import__(\"builtins\")"
     let defopts["HelpFormat"] = printf("try:exec(\"%s.help({0})\")\nexcept SyntaxError:%s.help(\"{0}\")", escape(python_builtins, "\"\\"), python_builtins)
     " let defopts["EvalFormat"] = printf("_={};print _')", python_builtins, python_builtins, python_builtins)
     " let defopts["EvalFormat"] = printf("__incpy__.sys.displayhook({})')")

--- a/python/incpy.py
+++ b/python/incpy.py
@@ -35,7 +35,7 @@ try:
                     else:
                         yield item
                     continue
-                return item
+                return
             def __insert__(self, index, value):
                 self.__backing__.insert(index, value)
             def __getitem__(self, index):

--- a/python/incpy.py
+++ b/python/incpy.py
@@ -2,7 +2,15 @@ import six, sys, logging
 logger = logging.getLogger('incpy').getChild('py')
 
 try:
-    import vim as _vim,exceptions
+    import vim as _vim
+
+    # Try python2's exceptions module first
+    try:
+        import exceptions
+
+    # Otherwise we're using Python3 and it's a builtin
+    except ImportError:
+        import builtins as exceptions
 
     # vim wrapper
     class vim(object):
@@ -235,11 +243,19 @@ except ImportError:
         import threading
         Thread, Event = map(staticmethod, (threading.Thread, threading.Event))
 
-        import Queue
-        Queue, QueueEmptyException = map(staticmethod, (Queue.Queue, Queue.Empty))
-
         import subprocess
         spawn, spawn_options = map(staticmethod, (subprocess.Popen, subprocess))
+
+        # Try importing with Python3's name first
+        try:
+            import queue as Queue
+
+        # Otherwise we'll try Python2's name
+        except ImportError:
+            import Queue
+
+        Queue, QueueEmptyException = map(staticmethod, (Queue.Queue, Queue.Empty))
+
 
 ### asynchronous process monitor
 import sys, os, weakref, time, itertools, shlex

--- a/python/incpy.py
+++ b/python/incpy.py
@@ -525,7 +525,10 @@ class process(object):
         Each thread will read from `pipe`, and stuff the value combined with `id` into `q`.
         """
         def stuff(q, *key):
-            while True: q.put(key + ((yield),))
+            while True:
+                item = (yield),
+                q.put(key + item)
+            return
 
         for id, pipe in itertools.chain([target], more):
             res, name = stuff(q, id), "{:s}<{!r}>".format(options.get('name', ''), id)

--- a/python/incpy.py
+++ b/python/incpy.py
@@ -185,7 +185,7 @@ try:
         def clear(self): self.buffer[:] = ['']
 
 except ImportError:
-    logger.warn('unable to import the vim module for python-vim. skipping the definition of its wrappers.')
+    logger.warning('unable to import the vim module for python-vim. skipping the definition of its wrappers.')
 
 try:
     # make sure the user has selected the gevent-based version by importing gevent

--- a/python/incpy.py
+++ b/python/incpy.py
@@ -15,7 +15,7 @@ try:
             def __new__(cls, prefix="", name=None):
                 ns = cls.__dict__.copy()
                 ns.setdefault('prefix', (prefix+':') if len(prefix)> 0 else prefix)
-                map(lambda n,d=ns: d.pop(n,None), ('__new__','__dict__','__weakref__'))
+                [ ns.pop(item, None) for item in ('__new__','__dict__','__weakref__') ]
                 result = type( (prefix+cls.__name__[1:]) if name is None else name, (object,), ns)
                 return result()
             def __getitem__(self, name):
@@ -35,7 +35,7 @@ try:
             if isinstance(n, six.string_types):
                 return "{!r}".format(n)
             if isinstance(n, list):
-                return "[{:s}]".format(','.join(map(cls._to,n)))
+                return "[{:s}]".format(','.join(map(cls._to, n)))
             if isinstance(n, dict):
                 return "{{{:s}}}".format(','.join((':'.join((cls._to(k), cls._to(v))) for k, v in six.iteritems(n))))
             raise Exception("Unknown type {:s} : {!r}".format(type(n),n))
@@ -53,7 +53,7 @@ try:
                 except ValueError: pass
                 return str(n)
             if isinstance(n, list):
-                return map(cls._from, n)
+                return [ cls._from(item) for item in n ]
             if isinstance(n, dict):
                 return { str(k) : cls._from(v) for k, v in six.iteritems(n) }
             return n
@@ -100,7 +100,7 @@ try:
             @classmethod
             def Function(cls, name):
                 def caller(*args):
-                    return cls.command("call {:s}({:s})".format(name,','.join(map(cls._to,args))))
+                    return cls.command("call {:s}({:s})".format(name, ','.join(map(cls._to, args))))
                 caller.__name__ = name
                 return caller
 
@@ -172,7 +172,7 @@ try:
         def write(self, data):
             result = iter(data.split('\n'))
             self.buffer[-1] += six.next(result)
-            map(self.buffer.append, result)
+            [ self.buffer.append(item) for item in result ]
 
         def clear(self): self.buffer[:] = ['']
 
@@ -394,7 +394,7 @@ class process(object):
             res = process.monitorPipe(self.taskQueue, (stdout, self.program.stdout), name=name)
 
         ## attach a friendly method that allows injection of data into the monitor
-        res = map(None, res)
+        res = list(res)
         for t, q in res: t.send = q.send
         threads, senders = zip(*res)
 
@@ -474,7 +474,7 @@ class process(object):
                     # determine why (cause...y'know..python), stop dancing so
                     # the parent will actually be able to terminate us
                     break
-                map(send, data)
+                [ send(item) for item in data ]
             return
 
         ## create our shuffling thread
@@ -601,7 +601,7 @@ class process(object):
         import operator
 
         # XXX: there should be a better way to block until all threads have joined
-        map(operator.methodcaller('join'), self.threads)
+        [ th.join() for th in self.threads ]
 
         # now spin until none of them are alive
         while len(self.threads) > 0:

--- a/python/incpy.py
+++ b/python/incpy.py
@@ -504,6 +504,7 @@ class process(object):
             options.update(dict(close_fds=False, startupinfo=si, creationflags=cf))
         else:
             options['close_fds'] = True
+        options['bufsize'] = 0
         options['cwd'] = cwd
         options['env'] = environment
         options['shell'] = shell


### PR DESCRIPTION
This PR modifies the plugin to support both Python2 and Python3. This is done via extensive usage of the `six` module, tweaking the syntax, expanding instances of `map` into list-comprehsnsions, implementing wrappers around vim's data types to handle unicode<->bytes conversion, and tweaking the interaction with the `subprocess` module.

This closes issue #1.