### PR TITLE
Moved the logic for showing the interpreter window on startup behind the "VimEnter" event.

### DIFF
--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -466,9 +466,6 @@ function! incpy#SetupPythonInterpreter(package)
     call incpy#SetupInterpreter(a:package)
     call incpy#SetupInterpreterView(a:package)
 
-    """ Set any of the specified options for the interpreter interface.
-    if g:incpy#WindowStartup | call incpy#Show() | endif
-
 endfunction
 
 """ Mapping of vim commands and keys
@@ -533,6 +530,10 @@ function! incpy#LoadPlugin()
     call incpy#SetupPythonInterpreter(g:incpy#PackageName)
     call incpy#SetupCommands()
     call incpy#SetupKeys()
+
+    " if we've been told to create a window on startup, then show the
+    " window when the "VimEnter" autocmd event has been triggered.
+    autocmd VimEnter * if g:incpy#WindowStartup | call incpy#Show() | endif
 
     " if we're using an external program, then we can just ignore the dotfile
     " since it really only makes sense when using the python interpreter.

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -467,7 +467,7 @@ function! incpy#SetupPythonInterpreter(package)
     call incpy#SetupInterpreterView(a:package)
 
     """ Set any of the specified options for the interpreter interface.
-    if g:incpy#WindowStartup | call incpy#Show() | endif
+    if g:incpy#WindowStartup && !(&diff)| call incpy#Show() | endif
 
 endfunction
 

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -467,7 +467,7 @@ function! incpy#SetupPythonInterpreter(package)
     call incpy#SetupInterpreterView(a:package)
 
     """ Set any of the specified options for the interpreter interface.
-    if g:incpy#WindowStartup && !(&diff)| call incpy#Show() | endif
+    if g:incpy#WindowStartup | call incpy#Show() | endif
 
 endfunction
 


### PR DESCRIPTION
One of the options, "`incpy#WindowStartup`", informs the plugin to create its interpreter window after the editor has been started. Unfortunately, this broke any editor logic which was responsible for also creating windows on startup. This affected "diff-mode" (started with `vimdiff`), and any of the open window parameters (`-oN` and `-ON`).

To avoid this conflict, the logic for "`incpy#WindowStartup`" has now been moved behind the "VimEnter" autocmd event. The "VimEnter" event is triggered after the editor has done all of its startup stuff. Thus, the theory is that all the window creation logic for the editor should be completed by the time the event happens. It is at this point that we can safely create the windows that were requested.

This fixes issue #10.