### PR TITLE
Added support for the Neovim editor and its variation on the terminal and job features.

### DIFF
--- a/autoload/incpy.vim
+++ b/autoload/incpy.vim
@@ -188,7 +188,7 @@ function! s:render_native_as_python(object)
         return printf('%d', a:object)
     elseif object_type == v:t_string
         return s:quote_single(a:object)
-    elseif object_type == v:t_none
+    elseif object_type is v:null
         return 'None'
     elseif object_type == v:t_float
         return printf('%f', a:object)

--- a/autoload/incpy.vim
+++ b/autoload/incpy.vim
@@ -341,7 +341,7 @@ function! s:generate_interpreter_cache_snippet(package)
 
         # grab the program specified by the user
         program = interface.vim.gvars["incpy#Program"]
-        use_terminal = interface.vim.has('terminal') and interface.vim.gvars["incpy#Terminal"]
+        use_terminal = (interface.vim.has('terminal') or interface.vim.has('nvim')) and interface.vim.gvars["incpy#Terminal"]
 
         # figure out which interpreter to use and then instantiate it.
         try:

--- a/autoload/incpy.vim
+++ b/autoload/incpy.vim
@@ -341,16 +341,17 @@ function! s:generate_interpreter_cache_snippet(package)
 
         # grab the program specified by the user
         program = interface.vim.gvars["incpy#Program"]
-        use_terminal = (interface.vim.has('terminal') or interface.vim.has('nvim')) and interface.vim.gvars["incpy#Terminal"]
+        use_terminal = any(interface.vim.has(feature) for feature in ['terminal', 'nvim']) and interface.vim.gvars["incpy#Terminal"]
 
         # figure out which interpreter to use and then instantiate it.
         try:
-            if len(program) > 0:
-                interpreter = interpreters.terminal if use_terminal else interpreters.external
-                cache = interpreter(program)
+            if len(program) > 0 and use_terminal:
+                interpreter = interpreters.neoterminal if interface.vim.has('nvim') else interpreters.terminal
+            elif len(program) > 0:
+                interpreter = interpreters.external
             else:
                 interpreter = interpreters.internal
-                cache = interpreter()
+            cache = interpreter(*[program] if program else [])
 
         # if we couldn't start the interpreter, then fall back to an internal one
         except Exception:

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -401,7 +401,7 @@ function! incpy#SetupOptions()
     let defopts["WindowStartup"] = v:true
 
     let defopts["Greenlets"] = v:false
-    let defopts["Terminal"] = has('terminal')
+    let defopts["Terminal"] = has('terminal') || has('nvim')
 
     let python_builtins = printf("__import__(%s)", s:quote_double('builtins'))
     let python_pydoc = printf("__import__(%s)", s:quote_double('pydoc'))
@@ -425,7 +425,9 @@ function! incpy#SetupOptions()
     endif
 
     " Default window options that the user will override
-    let defopts["CoreWindowOptions"] = {"buftype": has("terminal")? "terminal" : "nowrite", "swapfile": v:false, "updatecount":0, "buflisted": v:false}
+    let neo_window_options = {'buftype': 'nofile', 'swapfile': v:false, 'updatecount':0, 'buflisted': v:false}
+    let core_window_options = {'buftype': has('terminal')? 'terminal' : 'nowrite', 'swapfile': v:false, 'updatecount':0, 'buflisted': v:false}
+    let defopts["CoreWindowOptions"] = has('nvim')? neo_window_options : core_window_options
 
     " If any of these options aren't defined during evaluation, then go through and assign them as defaults
     for o in keys(defopts)
@@ -458,7 +460,7 @@ function! incpy#SetupPythonInterpreter(package)
 
     " Otherwise, we only need to warn the user about using it if they're
     " trying to run an external program without having the terminal api.
-    elseif len(g:incpy#Program) > 0 && !has("terminal")
+    elseif len(g:incpy#Program) > 0 && !(has('terminal') || has('nvim'))
         echohl WarningMsg | echomsg printf('WARNING:%s:Using plugin to run an external program without support for greenlets could be unstable', g:incpy#PluginName) | echohl None
     endif
 

--- a/python/interface.py
+++ b/python/interface.py
@@ -576,6 +576,9 @@ else:
                 return lines
             raise ValueError(position)
 
+        # add a property that selects between the regular terminal class and the neovim flavor'd one.
+        terminal = _accessor(get=lambda terminal=terminal, neo=neoterminal: neo if vim.has('nvim') else terminal)
+
 class buffer(object):
     """vim buffer management"""
 

--- a/python/interface.py
+++ b/python/interface.py
@@ -468,6 +468,98 @@ else:
                     raise vim.error("Unable to wait on the terminal job in buffer {:d} as it is not associated with a job.".format(buffer))
                 return vim.Function('term_wait')(buffer, *timeout)
 
+        class neoterminal(object):
+            """Internal neovim commands for interacting with terminal jobs by their buffer number"""
+            exists = staticmethod(lambda buffer: len(vim.eval("jobwait([{:d}], 0) != -3".format(buffer))) > 0)
+
+            # fortunately the &channel option seems to be immutable, so
+            # we can just query it from the buffer variables to extract it.
+            job = staticmethod(lambda buffer: vim.eval("getbufvar({:d}, '&channel')".format(buffer)))
+
+            @classmethod
+            def start(cls, cmd, **options):
+                '''Start the specified command as a terminal job and return the buffer number.'''
+                cwd = vim.eval("fnamemodify({:s}, ':~')".format('getcwd()'))
+                job = vim.eval("termopen({!r}, {!s})".format(cmd, options))
+
+                # XXX: we should be able to determine the buffer name from the `cwd`, `pid`, and
+                #      `cmd`, but (for some reason) "termopen" starts up multiple instances of the
+                #      neovim python provider when there are no writable buffers available for
+                #      replacement...or at least when neovim starts up..anyways.
+                #
+                #      somehow the aforementioned condition results in the wrong job id being
+                #      returned by our call to "termopen()". it is wrong in that it doesn't
+                #      correlate with the id from the "b:terminal_job_id" buffer variable. so,
+                #      when we use said job id to get the pid via "jobpid()", we get a completely
+                #      wrong process id. thus our entire predicted buffer name will be wrong.
+
+                #pid = vim.eval("jobpid({:d})".format(job))
+                #name = "term://{cwd}//{pid}:{command}".format(cwd=cwd, pid=pid, command=cmd)
+                #assert(vim.eval("bufexists('{:s}')".format(name.replace("'", "''"))))
+                #return vim.eval("bufnr('{:s}')".format(name.replace("'", "''")))
+
+                # we have no choice but to iterate through all of the buffers while
+                # trying to find the one where the '&channel' number matches our job.
+                infos = [info for info in vim.eval('getbufinfo()')]
+                filtered = [info for info in infos if 'terminal_job_id' in info.get('variables', {})]
+                matching = [info for info in filtered if info['variables']['terminal_job_id'] == job]
+
+                # now we just need to filter our matching results and return the buffer from them.
+                results = {info['bufnr'] for info in matching}
+                if len(results) != 1:
+                    raise vim.error("Unable to locate the buffer that is associated with job {:d}{:s}.".format(job, " ({:s})".format(', '.join(map("{:d}".format, results))) if results else ''))
+                elif not vim.eval("bufexists({:d})".format(*results)):
+                    raise vim.error("An error with the identified buffer ({:d}) for job {:d} has occurred as the buffer does not exist.".format(int(*results), job))
+                return int(*results)
+
+            @classmethod
+            def stop(cls, buffer):
+                '''Stop the terminal job running in the specified buffer.'''
+                if not cls.exists(buffer):
+                    raise vim.error("Unable to stop the job in buffer {:d} as it is not associated with a job.".format(buffer))
+                job = cls.job(buffer)
+                return vim.eval("jobstop({:d})".format(job))
+
+            @classmethod
+            def info(cls, buffer):
+                '''Return information for the terminal job in the specified buffer as a dictionary.'''
+                if not cls.exists(buffer):
+                    raise vim.error("Unable to get information for job in buffer {:d} as it is not associated with a job.".format(buffer))
+                job = cls.job(buffer)
+                pid = vim.eval("jobpid({:d})".format(job))
+                return {'process': pid}
+
+            @classmethod
+            def status(cls, buffer):
+                '''Return the status for the terminal job in the specified buffer as a string.'''
+                if not cls.exists(buffer):
+                    raise vim.error("Unable to get the status for job in buffer {:d} as it is not associated with a job.".format(buffer))
+                job = cls.job(buffer)
+                res = vim.eval("jobwait([{:d}], 0)".format(job))
+                if res == -1:
+                    return 'running'
+                return 'finished'
+
+            @classmethod
+            def send(cls, buffer, keys):
+                '''Send the given keystrokes to the terminal job in the specified buffer.'''
+                job = cls.job(buffer)
+
+                # neovim doesn't like us using newlines, so we need to give it
+                # a list if we want to send any keypresses that include them.
+                return vim.eval("chansend({:d}, {!r})".format(job, keys.split('\n')))
+
+            @classmethod
+            def wait(cls, buffer, *timeout):
+                '''Wait for any pending updates to the terminal job in the specified buffer.'''
+                if not cls.exists(buffer):
+                    raise vim.error("Unable to wait on the terminal job in buffer {:d} as it is not associated with a job.".format(buffer))
+
+                # there's no need to wait for things in neovim. apparently they
+                # assume that the buffer (window) will always be up-to-date. we
+                # still honor the sleep timeout, though, if we received one.
+                timeout and vim.eval("wait({:f}, {:s})".format(max(0, *timeout), 'v:false'))
+
         dimensions = _accessor(get=lambda: tuple(int(vim.eval('&' + option)) for option in ['columns', 'lines']))
         width = _accessor(get=lambda: int(vim.eval('&columns')))
         height = _accessor(get=lambda: int(vim.eval('&lines')))

--- a/python/interface.py
+++ b/python/interface.py
@@ -620,6 +620,7 @@ class buffer(object):
     def write(self, data):
         lines = iter(data.split('\n'))
         with vim.buffer.update(self.buffer) as buffer:
+            if not(len(buffer)): buffer[:] = ['']
             buffer[-1] += next(lines)
             [ buffer.append(item) for item in lines ]
         return


### PR DESCRIPTION
This PR modifies the `interface` and `interpreters` modules from the plugin so that it works correctly in Neovim. This also required updating the scripts to set some default window options that are compatible with Neovim's constraints. There were a couple of things that were also modified so that the same scripting logic can be used between both variations of the same editor.

Neovim's terminal API is different from Vim's in that starting a terminal job returns an identifier for the job. This identifier directly corresponds to the channel id for the job, so that the id can be used to facilitate communication with the job. Instead, Vim uses the buffer id to communicate to the terminal process. To accommodate this difference, an alternative namespace was added to the `python/interface.py` module which wraps the Neovim api, uses the job id to find the buffer that owns it, and then returns the number of that buffer.

Another terminal type was then added to `python/interpreters.py` as the `neoterminal` class. This additional terminal type inherits from the original `terminal` interpreter. Other than using the new terminal/job api, the `neoterminal` interpreter is also responsible for filtering out the buffer options that can't be applied in Neovim.

Additionally, some more fixes were included in order to support accessing the Python namespace from a Neovim provider. Terminal detection was tweaked to determine whether the `terminal` or `neoterminal` interpreter should be chosen, and the standard error from the spawned target process was combined into a single stream to avoid Neovim raising an exception when a newline is written to it.

This closes issue #16.