### PR TITLE
Fixed a regression that prevented the application of window options to the output window.

### DIFF
--- a/autoload/incpy.vim
+++ b/autoload/incpy.vim
@@ -400,12 +400,6 @@ function! s:get_window_options(other={})
         let result['preview'] = g:incpy#WindowPreview
     endif
 
-    " If the user wants the window to be fixed, then set the correct options.
-    if exists('g:incpy#WindowFixed') && g:incpy#WindowFixed
-        let result['winfixwidth'] = v:true
-        let result['winfixheight'] = v:true
-    endif
-
     " Merge in any custom window options that were assigned.
     for o in keys(g:incpy#WindowOptions)
         let result[o] = g:incpy#WindowOptions[o]

--- a/autoload/incpy.vim
+++ b/autoload/incpy.vim
@@ -394,7 +394,8 @@ function! s:get_window_options(other={})
         let result[o] = core[o]
     endfor
 
-    " Specially handle the window preview option.
+    " Specially handle the window preview option. This dictionary key isn't an
+    " option, but is used to influence the command used to create the window.
     if exists('g:incpy#WindowPreview')
         let result['preview'] = g:incpy#WindowPreview
     endif
@@ -405,7 +406,12 @@ function! s:get_window_options(other={})
         let result['winfixheight'] = v:true
     endif
 
-    " Merge any of the other options that we were given
+    " Merge in any custom window options that were assigned.
+    for o in keys(g:incpy#WindowOptions)
+        let result[o] = g:incpy#WindowOptions[o]
+    endfor
+
+    " Merge in any of the other options that we were given.
     for o in keys(a:other)
         let result[o] = a:other[o]
     endfor

--- a/doc/incpy.txt
+++ b/doc/incpy.txt
@@ -168,15 +168,13 @@ to be presented to the user. These options are as follows:
 	The ratio of the window size relative to the current window being
 	splitted. By default this ratio is set to `0.333333` or `1/3`.
 
-:let *g:incpy#WindowFixed* = (|Boolean|)
-	Specify whether the window width and height should be kept when
-	windows are opened or closed. This is responsible for setting the
-	|winfixheight| and |winfixwidth| options on the output window.
-
 :let *g:incpy#WindowOptions* = (|Dictionary|)
 	Customize the options for the window displaying the interpreter
 	output. This dictionary is used to set the local window options
-	using the |:setlocal| command.
+	using the |:setlocal| command. To prevent the editor from auto-
+	resizing the width or height of the output window when it is opened
+	or closed, the |winfixheight| and |winfixwidth| keys in this dictionary
+	can be set to `v:true`.
 
 :let *g:incpy#OutputFollow* = (|Boolean|)
 	Specify whether the interpreter window should always seek to the

--- a/doc/incpy.txt
+++ b/doc/incpy.txt
@@ -553,11 +553,13 @@ for emitting the result of an expression.
 	let g:incpy#WindowOptions = {
 	\	"filetype": "python",
 	\	"cursorcolumn": v:true,
-	\	"cursorline": v:true
+	\	"cursorline": v:true,
+	\	"winfixheight": v:false, "winfixwidth": v:false,
 	\}
 
 	let g:incpy#EchoFormat = '{}'
 	let g:incpy#EvalFormat = "__import__(\"sys\").displayhook(({}))\n"
+	let g:incpy#WindowPreview = v:true
 
 	let _ =<< trim EOS
 		%1$s.getpager = lambda: %1$s.plainpager

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -423,8 +423,22 @@ function! incpy#SetupOptions()
     endif
 
     " Default window options that the user will override
-    let neo_window_options = {'buftype': 'nofile', 'swapfile': v:false, 'updatecount':0, 'buflisted': v:false}
-    let core_window_options = {'buftype': has('terminal')? 'terminal' : 'nowrite', 'swapfile': v:false, 'updatecount':0, 'buflisted': v:false}
+    let neo_window_options = {
+    \   'buftype': 'nofile',
+    \   'swapfile': v:false,
+    \   'updatecount':0,
+    \   'buflisted': v:false,
+    \   'bufhidden': v:true,
+    \}
+
+    let core_window_options = {
+    \   'buftype': has('terminal')? 'terminal' : 'nofile',
+    \   'swapfile': v:false,
+    \   'updatecount':0,
+    \   'buflisted': v:false,
+    \   'bufhidden': v:true,
+    \}
+
     let defopts["CoreWindowOptions"] = has('nvim')? neo_window_options : core_window_options
 
     " If any of these options aren't defined during evaluation, then go through and assign them as defaults

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -75,7 +75,6 @@
 " string g:incpy#ExecStrip    -- describes how to strip input before being executed
 "
 " string g:incpy#WindowName     -- the name of the output buffer. defaults to "Scratch".
-" bool   g:incpy#WindowFixed    -- refuse to allow automatic resizing of the window.
 " dict   g:incpy#WindowOptions  -- the options to use when creating the output window.
 " bool   g:incpy#WindowPreview  -- whether to use preview windows for the program output.
 " float  g:incpy#WindowRatio    -- the ratio of the window size when creating it
@@ -397,7 +396,6 @@ function! incpy#SetupOptions()
     let defopts["WindowPosition"] = "below"
     let defopts["WindowOptions"] = {}
     let defopts["WindowPreview"] = v:false
-    let defopts["WindowFixed"] = 0
     let defopts["WindowStartup"] = v:true
 
     let defopts["Greenlets"] = v:false


### PR DESCRIPTION
This PR fixes a regression introduced by PR #11 that resulted in the custom window options specified in `g:incpy#WindowOptions` not being correctly applied to the output window. It does this by ensuring that the global variable actually gets merged into the dictionary returned by the `get_window_options` function. The core window options have also been tweaked to set the `bufhidden` variable to `v:true` to ensure that the output buffer doesn't get unloaded.

This PR also removes the `g:incpy#WindowFixed` option since it is completely unnecessary and can be specified by adding the `winfixheight` or `winfixwidth` options to `g:incpy#WindowOptions`. This was done by removing the special handling for it inside the `get_window_options` function. The documentation was updated to describe how fixed window resizing can be applied with `g:incpy#WindowOptions`, and to remove all references to `g:incpy#WindowFixed`.

This fixes issue #18.