### PR TITLE
Fixed the `incpy#Execute` function so that it strips its input like the `incpy#Range` function.

### DIFF
--- a/autoload/incpy.vim
+++ b/autoload/incpy.vim
@@ -424,16 +424,15 @@ function! incpy#Range(begin, end)
         throw printf("Unable to process the given input due to it being of an unsupported type (%s): %s", typename(input_stripped), input_stripped)
     endif
 
-    " Strip our input prior to its execution.
+    " Strip our input prior to its execution, then check its result type
+    " to ensure that we can pass to the interpreter without issue.
     let code_stripped = s:strip_by_option(g:incpy#ExecStrip, input_stripped)
-    call s:execute_interpreter_cache_guarded(['show'], map(['incpy#WindowPosition', 'incpy#WindowRatio'], 's:generate_gvar_expression(v:val)'), s:get_window_options())
-
-    " If it's not a list or a string, then we don't support it.
     if !(type(code_stripped) == v:t_string || type(code_stripped) == v:t_list)
-        throw printf("Unable to execute due to an unknown input type (%s): %s", typename(code_stripped), code_stripped)
+        throw printf("Unable to execute due to an unknown input type (%s) being returned by %s: %s", typename(code_stripped), 'g:incpy#ExecStrip', code_stripped)
     endif
 
-    " If we've got a string, then execute it as a single line.
+    " Show the window and then send each line to the interpreter.
+    call s:execute_interpreter_cache_guarded(['show'], map(['incpy#WindowPosition', 'incpy#WindowRatio'], 's:generate_gvar_expression(v:val)'), s:get_window_options())
     let l:commands_stripped = (type(code_stripped) == v:t_list)? code_stripped : [code_stripped]
     for command_stripped in l:commands_stripped
         call s:communicate_interpreter_encoded(s:singleline(g:incpy#ExecFormat, "\"\\"), command_stripped)
@@ -474,22 +473,18 @@ endfunction
 """ Plugin interaction interface
 function! incpy#Execute(line)
     let input_stripped = s:strip_by_option(g:incpy#InputStrip, a:line)
-
-    " Verify that the input returned is a type that we support
     if index([v:t_string, v:t_list], type(input_stripped)) < 0
         throw printf("Unable to process the given input due to it being of an unsupported type (%s): %s", typename(input_stripped), input_stripped)
     endif
 
-    " Strip our input prior to its execution.
+    " Now we need to strip our input for execution.
     let code_stripped = s:strip_by_option(g:incpy#ExecStrip, input_stripped)
-    call s:execute_interpreter_cache_guarded(['show'], map(['incpy#WindowPosition', 'incpy#WindowRatio'], 's:generate_gvar_expression(v:val)'), s:get_window_options())
-
-    " If it's not a list or a string, then we don't support it.
     if !(type(code_stripped) == v:t_string || type(code_stripped) == v:t_list)
-        throw printf("Unable to execute due to an unknown input type (%s): %s", typename(code_stripped), code_stripped)
+        throw printf("Unable to execute due to an unknown input type (%s) being returned by %s: %s", typename(code_stripped), 'g:incpy#ExecStrip', code_stripped)
     endif
 
-    " If we've got a string, then execute it as a single line.
+    " Show the window and send each line from our input to the interpreter.
+    call s:execute_interpreter_cache_guarded(['show'], map(['incpy#WindowPosition', 'incpy#WindowRatio'], 's:generate_gvar_expression(v:val)'), s:get_window_options())
     let l:commands_stripped = (type(code_stripped) == v:t_list)? code_stripped : [code_stripped]
     for command_stripped in l:commands_stripped
         call s:communicate_interpreter_encoded(s:singleline(g:incpy#ExecFormat, "\"\\"), command_stripped)


### PR DESCRIPTION
There are two commands that are used to communicate lines of code to an interpreter. One of them is `incpy#Execute`, where the other one is `incpy#Range`. The `incpy#Execute` function is used for communicating single lines, whereas `incpy#Range` is used for communicating multiple lines to the current interpreter. As the `incpy#Range` function can also be used for executing a single-line (if its start and end line are the same), it has essentially superceded the `incpy#Execute` function. This is made apparent by its usage for defining multiple commands that have been exposed to the user.

There is, however, one command which depends on the `incpy#Execute` function. This command is `Py` and is used specifically for communicating a single unformatted line to the interpreter. Unfortunately, the same logic has made its way into the implementation of the `incpy#ExecuteRaw` function introduced by commit 50703afc649a8137cdb88e654f71f4057e39a385, and used by the `PyRaw` command via commit b12a2867f9332164ed63b4995bd2d624e2d2bc41. These new functions/commands have essentially superceded the `incpy#Execute` function (and `Py`) accidentally.

As to the original intention of `incpy#Execute` was to submit unprocessed text to an interpreter, it does not strip its input in any way. Since the introduction of "raw" semantics via `incpy#ExecuteRaw`, it doesn't make sense for the `incpy#Execute` function to still work like this. So, this PR modifies the implementation of `incpy#Execute` so that it strips its input in the exact same way as `incpy#Range`. Really, the only reason why there is a separate function for this is for users who prefer to explicitly use the command to execute a single line.

This PR also tweaks `incpy#Range` and `incpy#Execute` so that they raise any input stripping exceptions prior to showing the interpreter output window.

This fixes issue #22.