### PR TITLE
Fixed an issue with executing a single line of folded code when in normal mode.

### DIFF
--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -486,7 +486,11 @@ endfunction
 
 " Create some vim commands that can interact with the plugin
 function! incpy#SetupCommands()
-    command PyLine call incpy#Range(foldlevel(line('.'))>0? foldclosed(line('.')) : line('.'), foldlevel(line('.'))>0? foldclosedend(line('.')) : line('.'))
+    if has('folding')
+        command PyLine call incpy#Range(foldlevel(line('.'))>0? foldclosed(line('.')) : line('.'), foldlevel(line('.'))>0? foldclosedend(line('.')) : line('.'))
+    else
+        command PyLine call incpy#Range(line("."), line("."))
+    endif
     command PyBuffer call incpy#Range(0, line('$'))
     command -range PyRange call incpy#Range(<line1>, <line2>)
 

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -486,7 +486,7 @@ endfunction
 
 " Create some vim commands that can interact with the plugin
 function! incpy#SetupCommands()
-    command PyLine call incpy#Range(line("."), line("."))
+    command PyLine call incpy#Range(foldlevel(line('.'))>0? foldclosed(line('.')) : line('.'), foldlevel(line('.'))>0? foldclosedend(line('.')) : line('.'))
     command PyBuffer call incpy#Range(0, line('$'))
     command -range PyRange call incpy#Range(<line1>, <line2>)
 


### PR DESCRIPTION
When executing a single line of code, the `PyLine` command is used to call `incpy#Range` with the current line as both of its parameters. Likewise, executing multiple lines is implemented in the exact same way by passing both the start and end line as the parameters to `incpy#Range`. This works in all cases because the `line()` function returns the true line numbers regardless of there being a fold or not.

When executing a single-line of folded code in normal-mode, however, the implementation of the `PyLine` command results in only a single line being executed discarding the contents of said fold. This is a side effect of its implementation using `line(.)` for both of its parameters. This PR remedies the issue by re-implementing the `PyLine` command so that it checks to see if the current line is folded with `foldlevel()` before determining which line numbers to use. If it is, the `foldclosed()` and `foldclosedend()` functions are used to get the current line numbers to pass to `incpy#Range`.

After some minor consideration, it was determined that the original definition for `PyLine` should probably be preserved. Therefore, the new definition is guarded by the existence of the "*+folding*" feature. If the editor does not support "*+folding*", then the original definition for the `PyLine` command is used.

This fixes issue #20.