### PR TITLE
Fixed an issue with stripping a string using a function reference as its option.

### DIFF
--- a/autoload/incpy.vim
+++ b/autoload/incpy.vim
@@ -138,7 +138,7 @@ function! s:stripstring_by_option(option, string)
 
     elseif type(a:option) == v:t_func
         let F = a:option
-        let result = F(a:string)
+        let result = F([a:string])
 
     else
         throw printf("Unable to strip string due to an unknown filtering option (%s): %s", typename(a:option), a:option)


### PR DESCRIPTION
The logic for allowing a user to customize the stripping and formatting of input being sent to an interpreter depends on the implementation of the `s:strip_by_option` function from "autoload/incpy.vim". This functions checks the type of the parameter to distinguish which methodology to use for stripping its input. If a string is passed as the parameter, the `s:stripstring_by_option` function will be used.

The issue is that when a function is used as a parameter to strip the string, the `s:stripstring_by_option` function will incorrectly pass the entire string to the option function. This conflicts with the default stripping implementation since it's written so that if a function is configured, its parameter should always be treated as a list per the documentation.

To fix this, we simply wrap the input as a list before passing it to the option function.

This fixes issue #25.