### PR TITLE
Replaced all instances of the slice() function with an explicit list slice operator.

### DIFF
--- a/autoload/incpy/internal.vim
+++ b/autoload/incpy/internal.vim
@@ -42,7 +42,7 @@ function! incpy#internal#execute_guarded(package, method, parameters, keywords={
     let l:cache = [printf('__import__(%s)', incpy#string#quote_single(a:package)), 'cache']
     let l:method = (type(a:method) == v:t_list)? a:method : [a:method]
     let l:kwparameters = len(a:keywords)? [printf('**%s', incpy#python#render(a:keywords))] : []
-    call incpy#internal#workspace(a:package, printf("hasattr(%s, %s) and %s(%s)", join(slice(l:cache, 0, -1), '.'), incpy#string#quote_single(l:cache[-1]), join(l:cache + l:method, '.'), join(a:parameters + l:kwparameters, ', ')))
+    call incpy#internal#workspace(a:package, printf("hasattr(%s, %s) and %s(%s)", join(l:cache[0 : -1]), '.'), incpy#string#quote_single(l:cache[-1]), join(l:cache + l:method, '.'), join(a:parameters + l:kwparameters, ', ')))
 endfunction
 
 " Send the specified a:code to the interpreter that is stored within the

--- a/autoload/incpy/ui/selection.vim
+++ b/autoload/incpy/ui/selection.vim
@@ -26,7 +26,7 @@ function! incpy#ui#selection#range() range
 
     let lines = getline(l:minline, l:maxline)
     if len(lines) > 2
-        let selection = [strcharpart(lines[0], l:minchar - 1)] + slice(lines, 1, -1) + [strcharpart(lines[-1], 0, l:maxchar)]
+        let selection = [strcharpart(lines[0], l:minchar - 1)] + lines[+1 : -1] + [strcharpart(lines[-1], 0, l:maxchar)]
     elseif len(lines) > 1
         let selection = [strcharpart(lines[0], l:minchar - 1)] + [strcharpart(lines[-1], 0, l:maxchar)]
     else


### PR DESCRIPTION
Older versions of neovim seem to have not implemented the `slice()` function. This PR takes care of that by replacing all instances of `slice()` with the regular slice-operator for lists. Hopefully that'll make it work for prior versions as well.

This PR only involved fixing the `incpy#internal#execute_guarded` function for executing code in Vim's internal python interpreter and the `incpy#ui#selection#range` utility which is used to fetch the visually-selected text.

This fixes issue #32.