### PR TITLE
Added a configuration option to toggle whether the default key mappings are applied on startup.

### DIFF
--- a/autoload/incpy.vim
+++ b/autoload/incpy.vim
@@ -110,6 +110,12 @@ endfunction
 
 function! incpy#SetupBindings()
     call incpy#bindings#mappings()
-    call incpy#bindings#keys()
+
+    " Only setup the keybindings if the incpy#UseDefaultMappings is set.
+    if !exists('g:incpy#UseDefaultMappings') || g:incpy#UseDefaultMappings
+        call incpy#bindings#keys()
+    endif
+
+    " Set up the terminal-mode keybindings because they always make sense.
     call incpy#bindings#terminal()
 endfunction

--- a/autoload/incpy.vim
+++ b/autoload/incpy.vim
@@ -109,5 +109,7 @@ function! incpy#SetupCommands()
 endfunction
 
 function! incpy#SetupKeys()
-    return incpy#bindings#setup()
+    call incpy#bindings#mappings()
+    call incpy#bindings#keys()
+    call incpy#bindings#terminal()
 endfunction

--- a/autoload/incpy.vim
+++ b/autoload/incpy.vim
@@ -108,7 +108,7 @@ function! incpy#SetupCommands()
     return incpy#bindings#commands()
 endfunction
 
-function! incpy#SetupKeys()
+function! incpy#SetupBindings()
     call incpy#bindings#mappings()
     call incpy#bindings#keys()
     call incpy#bindings#terminal()

--- a/autoload/incpy/bindings.vim
+++ b/autoload/incpy/bindings.vim
@@ -30,27 +30,60 @@ function! incpy#bindings#commands()
     command -range PyHelpSelection <line1>,<line2>call incpy#interpreter#halp_selected()
 endfunction
 
-" Set up the default key mappings for vim to use the plugin
-function! incpy#bindings#setup()
+" Set up the plugin mappings for the available commands
+function! incpy#bindings#mappings()
 
     " Execute a single or range of lines
-    nnoremap ! :PyLine<C-M>
-    vnoremap ! :PyRange<C-M>
+    nnoremap <silent> <Plug>(IncExecuteLine) :PyLine<CR>
+    xnoremap <silent> <Plug>(IncExecuteRange) :PyExecuteRange<CR>
+    xnoremap <silent> <Plug>(IncExecuteBlock) :PyExecuteBlock<CR>
+    snoremap <silent> <Plug>(IncExecuteSelection) :PyExecuteSelection<CR>
 
     " Python visual and normal mode mappings
-    nnoremap <C-/> :call incpy#interpreter#evaluate(<SID>keyword_under_cursor())<C-M>
-    vnoremap <C-/> :PyEvalRange<C-M>
+    nnoremap <silent> <Plug>(IncEvaluateKeyword) <Cmd>call incpy#interpreter#evaluate(<SID>keyword_under_cursor())<CR>
+    xnoremap <silent> <Plug>(IncEvaluteRange) :PyEvalRange<CR>
+    xnoremap <silent> <Plug>(IncEvaluteBlock) :PyEvalBlock<CR>
+    snoremap <silent> <Plug>(IncEvaluteSelection) :PyEvalSelection<CR>
 
-    nnoremap <C-\> :call incpy#interpreter#evaluate(<SID>keyword_under_cursor())<C-M>
-    vnoremap <C-\> :PyEvalRange<C-M>
+    " Normal and visual mode mappings
+    nnoremap <silent> <Plug>(IncHelpKeyword) <Cmd>call incpy#interpreter#halp(<SID>keyword_under_cursor())<CR>
+    xnoremap <silent> <Plug>(IncHelpSelection) :PyHelpSelection<CR>
+
+    " Miscellaneous mappings
+    nnoremap <silent> <Plug>(IncExecuteBuffer) :PyBuffer<CR>
+    nnoremap <silent> <Plug>(IncExecuteRaw) :PyRaw<CR>
+
+endfunction
+
+" Set up the default key mappings for vim to use the plugin
+function! incpy#bindings#keys()
+
+    " Execute a single or range of lines
+    nnoremap ! <Plug>(IncExecuteLine)
+    vnoremap ! <Plug>(IncExecuteRange)
+    snoremap ! <Plug>(IncExecuteSelection)
+
+    " Python visual and normal mode mappings
+    nnoremap <C-/> <Plug>(IncEvaluateKeyword)
+    vnoremap <C-/> <Plug>(IncEvaluateRange)
+    snoremap <C-/> <Plug>(IncEvaluateSelection)
+
+    " Some terminals don't recognize <C-/>, so we add <C-\> just in case.
+    nnoremap <C-\> <Plug>(IncEvaluateKeyword)
+    vnoremap <C-\> <Plug>(IncEvaluateRange)
+    snoremap <C-\> <Plug>(IncEvaluateSelection)
 
     " Normal and visual mode mappings for windows
-    nnoremap <C-@> :call incpy#interpreter#halp(<SID>keyword_under_cursor())<C-M>
-    vnoremap <C-@> :PyHelpSelection<C-M>
+    nnoremap <C-@> <Plug>(IncHelpKeyword)
+    vnoremap <C-@> <Plug>(IncHelpSelection)
 
     " Normal and visual mode mappings for everything else
-    nnoremap <C-S-@> :call incpy#interpreter#halp(<SID>keyword_under_cursor())<C-M>
-    vnoremap <C-S-@> :PyHelpSelection<C-M>
+    nnoremap <C-S-@> <Plug>(IncHelpKeyword)
+    vnoremap <C-S-@> <Plug>(IncHelpSelection)
+
+endfunction
+
+function! incpy#bindings#terminal()
 
     " If we have terminal support, then add a mapping that makes
     " pasting from a register similar to cmdline-mode.
@@ -62,4 +95,5 @@ function! incpy#bindings#setup()
         tnoremap <silent> <C-R>= <Cmd>call chansend(b:terminal_job_id, eval(input('=')))<CR>
         tnoremap <silent> <C-R> <Cmd>call chansend(b:terminal_job_id, getreg(nr2char(getchar())))<CR>
     endif
+
 endfunction

--- a/doc/incpy.txt
+++ b/doc/incpy.txt
@@ -195,6 +195,15 @@ to be presented to the user. These options are as follows:
 	this will use the value of the |$PYTHONSTARTUP| environment variable,
 	or |$HOME/.pythonrc.py| if the environment variable is not available.
 
+:let *g:incpy#UseDefaultMappings* = (|Boolean|)
+	This variable is used by the plugin to determine whether the default
+	keybindings should be mapped. By default this is set to `v:true` and
+	is only processed when the plugin is loaded. If this global has been
+	set to `v:false`, the plugin will not map anything for |normal-mode|,
+	|visual-mode|, or |select-mode|. If this is the case, the user will
+	need to manually customize their mappings using the internal mappings
+	that are documented in the |incpy-mappings| section.
+
 ==============================================================================
 CONFIGURATION (EXTERNAL)			*incpy-configuration-external*
 

--- a/doc/incpy.txt
+++ b/doc/incpy.txt
@@ -10,17 +10,18 @@ CONTENTS						*incpy-contents*
 	4. Configuration			|incpy-configuration|
 	4.1. Configuration (External)		|incpy-configuration-external|
 	5. Commands				|incpy-commands|
-	6. Public API				|incpy-functions|
-	7. Configuration Examples		|incpy-examples|
-	7.1 Example - Python			|incpy-examples-python|
-	7.2 Example - Perl			|incpy-examples-perl|
-	7.3 Example - Bash			|incpy-examples-bash|
-	7.4 Example - F#			|incpy-examples-fsharp|
-	7.5 Example - Node			|incpy-examples-nodejs|
-	7.6 Example - SWI-Prolog		|incpy-examples-prolog|
-	8. Development and Bugs			|incpy-bugs|
-	9. History				|incpy-history|
-	10. Credits				|incpy-credits|
+	6. Mappings				|incpy-mappings|
+	7. Public API				|incpy-functions|
+	8. Configuration Examples		|incpy-examples|
+	8.1 Example - Python			|incpy-examples-python|
+	8.2 Example - Perl			|incpy-examples-perl|
+	8.3 Example - Bash			|incpy-examples-bash|
+	8.4 Example - F#			|incpy-examples-fsharp|
+	8.5 Example - Node			|incpy-examples-nodejs|
+	8.6 Example - SWI-Prolog		|incpy-examples-prolog|
+	9. Development and Bugs			|incpy-bugs|
+	10. History				|incpy-history|
+	11. Credits				|incpy-credits|
 
 ==============================================================================
 INTRODUCTION							*incpy-intro*
@@ -400,6 +401,46 @@ can be called directly.
 :PyHelpSelection
 	View the |Python| help for the currently selected text. This uses the
 	|incpy#HalpSelected| public function for its implementation.
+
+==============================================================================
+MAPPINGS						*incpy-mappings*
+
+The plugin exposes the following internal mappings which can be used with the
+|<Plug>| key name to customize the keys used to execute the plugin. For more
+information, please review the |using-<Plug>| section within the manual.
+
+==============================================================
+| Mapping                        | Command                   |
+==============================================================
+| <Plug>(IncExecuteLine)         | |:PyLine|                   |
+--------------------------------------------------------------
+| <Plug>(IncExecuteRange)        | |:PyExecuteRange|           |
+--------------------------------------------------------------
+| <Plug>(IncExecuteSelection)    | |:PyExecuteSelection|       |
+--------------------------------------------------------------
+| <Plug>(IncEvaluateKeyword)     | |:PyEvaluateKeyword|        |
+--------------------------------------------------------------
+| <Plug>(IncEvaluateRange)       | |:PyEvaluateRange|          |
+--------------------------------------------------------------
+| <Plug>(IncEvaluateSelection)   | |:PyEvaluateSelection|      |
+--------------------------------------------------------------
+| <Plug>(IncHelpKeyword)         | |:PyHelpKeyword|            |
+--------------------------------------------------------------
+| <Plug>(IncHelpSelection)       | |:PyHelpSelection|          |
+--------------------------------------------------------------
+
+The following example demonstrates the using the previously listed mappings in
+order to bind them to specific keypresses.
+>
+	nnoremap !	<Plug>(IncExecuteLine)
+	vnoremap !	<Plug>(IncExecuteRange)
+	nnoremap <C-/>	<Plug>(IncEvaluateKeyword)
+	vnoremap <C-/>	<Plug>(IncEvaluateRange)
+	nnoremap <C-@>	<Plug>(IncHelpKeyword)
+	vnoremap <C-@>	<Plug>(IncHelpSelection)
+<
+These are the default mappings that are set when the plugin is loaded and is
+described in detail within the |incpy-usage| section.
 
 ==============================================================================
 PUBLIC API						*incpy-functions*

--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -150,7 +150,7 @@ function! incpy#LoadPlugin()
     call incpy#SetupPythonLoader(g:incpy#PackageName, s:current_script)
     call incpy#SetupPythonInterpreter(g:incpy#PackageName)
     call incpy#SetupCommands()
-    call incpy#SetupKeys()
+    call incpy#SetupBindings()
 
     " if we've been told to create a window on startup, then show the
     " window when the "VimEnter" autocmd event has been triggered.


### PR DESCRIPTION
Most of the functionality of the plugin is exposed to the user using the commands that are found in the `incpy#bindings` namespace. These commands are then mapped to specific keys on startup for the user to interact with them. It was suggested in issue #28 that customization of these keys would be more in line with other plugins if we attached the commands to mappings that use the "\<Plug\>" key name.

This PR does that by splitting up the original `incpy#bindings#setup` function into three parts. One part uses "\<Plug\>" key to actually map the commands, the next part which applies key bindings to "terminal-mode", and the last part which actually applies the "\<Plug\>" mappings to keys for "normal-mode", "visual-mode", and "select-mode". The `incpy#SetupKeys` wrapper was renamed to `incpy#SetupBindings`, and a guard was added to avoid applying keybindings if the `g:incpy#UseDefaultMappings` global is set to `v:false`.

This fixes issue #28.