### PR TITLE
Refactored the current script detection for compatibility with older versions of Neovim.

### DIFF
--- a/plugin/incpy.vim
+++ b/plugin/incpy.vim
@@ -109,6 +109,13 @@ if exists("g:loaded_incpy") && g:loaded_incpy
 endif
 let g:loaded_incpy = v:true
 
+" Assign the current script as a script-local variable due to the issue from
+" arizvisa/vim-incpy#30. Essentially, older versions of Neovim have a bug in
+" that expand("<sfile>") returns the wrong path when called from a function.
+" This was fixed in regular Vim by the 8.2.1297 patch. So, to work around this
+" regression, we assign it at the script-level and then access it as a global.
+let s:current_script = expand("<sfile>:p:h")
+
 " Add a virtual package with the specified name referencing the given path.
 function! incpy#SetupPythonLoader(package, currentscriptpath)
     let l:slashes = substitute(a:currentscriptpath, "\\", "/", "g")
@@ -144,8 +151,6 @@ endfunction
 
 "" Entry point
 function! incpy#LoadPlugin()
-    let s:current_script=expand("<sfile>:p:h")
-
     call incpy#SetupOptions()
     call incpy#SetupPythonLoader(g:incpy#PackageName, s:current_script)
     call incpy#SetupPythonInterpreter(g:incpy#PackageName)


### PR DESCRIPTION
On older versions of NeoVim, the 8.2.1297 patch wasn't merged until later in its lifetime. That patchset resulted in fixing an issue that would cause expand("<sfile>") to return an incorrect base path when called by a function that is being executed during initialization.

To avoid the condition that triggers this bug, we grab the current script path from a different scope when loading the python parts of the plugin. By grabbing it from a different scope, we work around the original cause of the issue.

This fixes issue #30.