### PR TITLE
Tweaked the functions from `incpy#interpreter` to avoid executing or evaluating empty strings.

### DIFF
--- a/autoload/incpy/interpreter.vim
+++ b/autoload/incpy/interpreter.vim
@@ -108,8 +108,8 @@ function! incpy#interpreter#evaluate(expr)
 
     " Evaluate an expression in the target using the plugin. If the stripped
     " expression is an empty string (or list), then there's nothing to do.
+    call incpy#internal#execute_guarded(g:incpy#PackageName, ['show'], map(['incpy#WindowPosition', 'incpy#WindowRatio'], 'incpy#python#global_variable(v:val)'), incpy#options#window())
     if len(stripped) > 0
-        call incpy#internal#execute_guarded(g:incpy#PackageName, ['show'], map(['incpy#WindowPosition', 'incpy#WindowRatio'], 'incpy#python#global_variable(v:val)'), incpy#options#window())
         call incpy#internal#communicate(g:incpy#PackageName, incpy#string#singleline(g:incpy#EvalFormat, "\"\\"), stripped)
     endif
 

--- a/autoload/incpy/options.vim
+++ b/autoload/incpy/options.vim
@@ -11,7 +11,7 @@ let s:PYTHONRC_FILE_NAME = '.pythonrc.py'
 let s:core_window_options = {
 \   'buftype': has('terminal')? 'terminal' : 'nofile',
 \   'swapfile': v:false,
-\   'updatecount':0,
+\   'updatecount': 0,
 \   'buflisted': v:false,
 \   'bufhidden': 'hide',
 \}
@@ -20,7 +20,7 @@ let s:core_window_options = {
 let s:neo_window_options = {
 \   'buftype': 'nofile',
 \   'swapfile': v:false,
-\   'updatecount':0,
+\   'updatecount': 0,
 \   'buflisted': v:false,
 \   'bufhidden': 'hide',
 \}


### PR DESCRIPTION
When executing or evaluating code with the `incpy#interpreter` namespace, the plugin processes the selected text using a few customizeable options for stripping the code, and then formatting it for execution. The logic for stripping code being evaluated is done using the `incpy#EvalStrip` option, where the `incpy#ExecStrip` option is used for code being executed. Once the code has been stripped, the `incpy#EvalFormat` (for evaluation) or `incpy#ExecFormat` (for execution) is used to format the selected code before submitting it to the interpreter.

Due to the ability to customize the evaluation (`incpy#EvalFormat`) or execution (`incpy#ExecFormat`) of the code. If an empty string is submitted to either of these functions, the interpreter may still attempt to submit code to the target binary.

This issue can also manifest when using a terribly written function for either the `incpy#EvalStrip` or `incpy#ExecStrip` options. Since we're trying to be robust, we need to accommodate users that return a list containing an empty string as one of its elements.

This PR fixes the issue by adding guards against empty strings in both the `incpy#interpreter#range` and `incpy#interpreter#execute` functions. The `incpy#interpreter#evaluate` function was also updated to check for a non-empty expression prior to evaluation. It is worth noting that we still attempt to show the window whether or not code has been executed or evaluated.

This fixes issue #38.